### PR TITLE
Fix: moved banner config from cloudcannon.config.yml to data/banner.yml

### DIFF
--- a/cloudcannon.config.yml
+++ b/cloudcannon.config.yml
@@ -417,23 +417,6 @@ _inputs:
   shortcut_icon:
     type: image
     comment: Bookmark icon
-  enable_banner:
-    type: switch
-  html:
-    type: html
-    label: Banner Content
-    hidden: '!enable_banner'
-  id:
-    type: text
-    label: Unique ID
-    hidden: '!enable_banner'
-    comment: Prevents repeated display for users who close the banner, changing ID resets for all.
-  show_until:
-    type: date
-    comment: Date to stop showing the banner
-    hidden: '!enable_banner'
-
-
   
 
 # Snippets

--- a/cloudcannon.config.yml
+++ b/cloudcannon.config.yml
@@ -10,7 +10,7 @@ collections_config:
     parse_branch_index: true
     disable_add_folder: true
     path: content
-    base_url: https://aware-daffodil.cloudvent.net
+    base_url: /
     icon: feed
     schemas:
       default:

--- a/cloudcannon.config.yml
+++ b/cloudcannon.config.yml
@@ -10,7 +10,7 @@ collections_config:
     parse_branch_index: true
     disable_add_folder: true
     path: content
-    base_url: /
+    base_url: https://aware-daffodil.cloudvent.net
     icon: feed
     schemas:
       default:

--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,4 @@
-baseURL: /
+baseURL: https://aware-daffodil.cloudvent.net/
 languageCode: en-us
 title: Alto Template
 summaryLength: 30

--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,4 @@
-baseURL: /
+baseURL: https://aware-daffodil.cloudvent.net
 languageCode: en-us
 title: Alto Template
 summaryLength: 30

--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,4 @@
-baseURL: /what_happens/
+baseURL: /
 languageCode: en-us
 title: Alto Template
 summaryLength: 30

--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,4 @@
-baseURL: https://aware-daffodil.cloudvent.net/
+baseURL: /
 languageCode: en-us
 title: Alto Template
 summaryLength: 30

--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,4 @@
-baseURL: /
+baseURL: /what_happens/
 languageCode: en-us
 title: Alto Template
 summaryLength: 30

--- a/content/_index.md
+++ b/content/_index.md
@@ -10,7 +10,16 @@ draft: false
 ---
 Alto is a minimal and modern Hugo theme for static documentation sites, created by and optimized for <a target="_blank" rel="noopener" href="https://cloudcannon.com">CloudCannon</a>.
 
-
+{{<diffcode>}}
+```js
+new PagefindUI({
+    element: "#search",
++    mergeIndex: [{
++        bundlePath: "https://docs.example.com/_pagefind"
++    }]
+})
+```
+{{</diffcode>}}
 
 Designed initially for open-source software, Alto has many built-in features to aid both site users and documentation writers:
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -14,9 +14,9 @@ Alto is a minimal and modern Hugo theme for static documentation sites, created 
 
 
 
-{{< ref path="docs" >}}
+{{< ref path="https://aware-daffodil.cloudvent.net/docs" >}}
 
-{{< relref path="docs" >}}
+{{< relref path="https://aware-daffodil.cloudvent.net/docs" >}}
 
 Designed initially for open-source software, Alto has many built-in features to aid both site users and documentation writers:
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -10,7 +10,7 @@ draft: false
 ---
 Alto is a minimal and modern Hugo theme for static documentation sites, created by and optimized for <a target="_blank" rel="noopener" href="https://cloudcannon.com">CloudCannon</a>.
 
-{{< ref path="https://google.com" >}}
+{{< ref path="docs/_index" >}}
 
 {{< relref path="docs/_index.md" >}}
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -8,14 +8,6 @@ SEO_options:
   description:
 draft: false
 ---
-{{< vimeo id="" >}}
-
-{{< youtube id="fDA-cTPv6kU?si=TA3EphK60g_r2jXh" >}}
-
-{{< figure src="/uploads/alto.png" title="werwerwerwerwerwr" caption="wwe" link="/" target="wer" rel="werewr" attr="werwer" >}}
-
-{{< gist "dirtystylus" "d488ea82fec9ebda8308a288015d019b" >}}
-
 Alto is a minimal and modern Hugo theme for static documentation sites, created by and optimized for <a target="_blank" rel="noopener" href="https://cloudcannon.com">CloudCannon</a>.
 
 Designed initially for open-source software, Alto has many built-in features to aid both site users and documentation writers:

--- a/content/_index.md
+++ b/content/_index.md
@@ -12,12 +12,6 @@ Alto is a minimal and modern Hugo theme for static documentation sites, created 
 
 
 
-
-
-{{< ref path="https://aware-daffodil.cloudvent.net/docs" >}}
-
-{{< relref path="https://aware-daffodil.cloudvent.net/docs" >}}
-
 Designed initially for open-source software, Alto has many built-in features to aid both site users and documentation writers:
 
 * Built-in static search with <a target="_blank" rel="noopener" href="https://pagefind.app">Pagefind</a>;

--- a/content/_index.md
+++ b/content/_index.md
@@ -14,7 +14,9 @@ Alto is a minimal and modern Hugo theme for static documentation sites, created 
 
 
 
+{{< ref path="docs" >}}
 
+{{< relref path="docs" >}}
 
 Designed initially for open-source software, Alto has many built-in features to aid both site users and documentation writers:
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -12,9 +12,9 @@ Alto is a minimal and modern Hugo theme for static documentation sites, created 
 
 {{< figure src="/uploads/alto.png" >}}
 
+{{< ref path="_index.md" >}}
 
-
-
+{{< relref path="_index.md" >}}
 
 Designed initially for open-source software, Alto has many built-in features to aid both site users and documentation writers:
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -8,7 +8,7 @@ SEO_options:
   description:
 draft: false
 ---
-Alto is a minimal and modern Hugo theme for static documentation sites, created by and optimized for <a target="_blank" rel="noopener" href="https://cloudcannon.com">CloudCannon</a>.
+Alto is a minimal and modern Hugo theme for static documentation sites, created by and optimized for <a target="_blank" rel="noopener" href="https://cloudcannon.com">CloudCannon</a>.{{< ref path="home" lang="html" outputFormat="html" >}}
 
 Designed initially for open-source software, Alto has many built-in features to aid both site users and documentation writers:
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -8,7 +8,11 @@ SEO_options:
   description:
 draft: false
 ---
-Alto is a minimal and modern Hugo theme for static documentation sites, created by and optimized for <a target="_blank" rel="noopener" href="https://cloudcannon.com">CloudCannon</a>.{{< ref path="docs/_index.md" >}}
+Alto is a minimal and modern Hugo theme for static documentation sites, created by and optimized for <a target="_blank" rel="noopener" href="https://cloudcannon.com">CloudCannon</a>.
+
+{{< ref path="docs/_index.md" >}}
+
+{{< relref path="docs/index.md" >}}
 
 Designed initially for open-source software, Alto has many built-in features to aid both site users and documentation writers:
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -10,13 +10,11 @@ draft: false
 ---
 Alto is a minimal and modern Hugo theme for static documentation sites, created by and optimized for <a target="_blank" rel="noopener" href="https://cloudcannon.com">CloudCannon</a>.
 
-{{< figure src="/uploads/alto.png" >}}
 
-{{< ref path="docs" >}}
 
-{{< relref path="docs" >}}
 
-{{< param "" >}}
+
+
 
 Designed initially for open-source software, Alto has many built-in features to aid both site users and documentation writers:
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -14,7 +14,9 @@ Alto is a minimal and modern Hugo theme for static documentation sites, created 
 
 {{< ref path="docs" >}}
 
-{{< relref path="_index.md" >}}
+{{< relref path="docs" >}}
+
+{{< param "" >}}
 
 Designed initially for open-source software, Alto has many built-in features to aid both site users and documentation writers:
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -8,7 +8,7 @@ SEO_options:
   description:
 draft: false
 ---
-Alto is a minimal and modern Hugo theme for static documentation sites, created by and optimized for <a target="_blank" rel="noopener" href="https://cloudcannon.com">CloudCannon</a>.{{< ref path="pages/index.md" lang="md" outputFormat="html" >}}
+Alto is a minimal and modern Hugo theme for static documentation sites, created by and optimized for <a target="_blank" rel="noopener" href="https://cloudcannon.com">CloudCannon</a>.{{< ref path="/pages/index.md" lang="md" outputFormat="html" >}}
 
 Designed initially for open-source software, Alto has many built-in features to aid both site users and documentation writers:
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -24,6 +24,17 @@ Designed initially for open-source software, Alto has many built-in features to 
 
 To get started with Alto, create a CloudCannon account and check out the [Getting Started documentation](/docs/).
 
+{{<tree>}}
+package.json
+_includes/
+>> _layouts/
+>  >> default.liquid
+>  >> page.liquid
+>> file.liquid
+_site/
+>> index.html
+{{</tree>}}
+
 <!--more-->
 
 ## Showcase

--- a/content/_index.md
+++ b/content/_index.md
@@ -12,6 +12,10 @@ draft: false
 
 {{< youtube id="fDA-cTPv6kU?si=TA3EphK60g_r2jXh" >}}
 
+{{< figure src="/uploads/alto.png" title="werwerwerwerwerwr" caption="wwe" link="/" target="wer" rel="werewr" attr="werwer" >}}
+
+{{< gist "dirtystylus" "d488ea82fec9ebda8308a288015d019b" >}}
+
 Alto is a minimal and modern Hugo theme for static documentation sites, created by and optimized for <a target="_blank" rel="noopener" href="https://cloudcannon.com">CloudCannon</a>.
 
 Designed initially for open-source software, Alto has many built-in features to aid both site users and documentation writers:

--- a/content/_index.md
+++ b/content/_index.md
@@ -8,7 +8,7 @@ SEO_options:
   description:
 draft: false
 ---
-Alto is a minimal and modern Hugo theme for static documentation sites, created by and optimized for <a target="_blank" rel="noopener" href="https://cloudcannon.com">CloudCannon</a>.{{< ref path="google.com" lang="html" outputFormat="html" >}}
+Alto is a minimal and modern Hugo theme for static documentation sites, created by and optimized for <a target="_blank" rel="noopener" href="https://cloudcannon.com">CloudCannon</a>.{{< ref path="pages/index.md" lang="md" outputFormat="html" >}}
 
 Designed initially for open-source software, Alto has many built-in features to aid both site users and documentation writers:
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -8,6 +8,10 @@ SEO_options:
   description:
 draft: false
 ---
+{{< vimeo id="" >}}
+
+{{< youtube id="fDA-cTPv6kU?si=TA3EphK60g_r2jXh" >}}
+
 Alto is a minimal and modern Hugo theme for static documentation sites, created by and optimized for <a target="_blank" rel="noopener" href="https://cloudcannon.com">CloudCannon</a>.
 
 Designed initially for open-source software, Alto has many built-in features to aid both site users and documentation writers:
@@ -23,7 +27,6 @@ Designed initially for open-source software, Alto has many built-in features to 
 * Optimized for editing and publishing on CloudCannon.
 
 To get started with Alto, create a CloudCannon account and check out the [Getting Started documentation](/docs/).
-
 
 <!--more-->
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -24,7 +24,7 @@ Designed initially for open-source software, Alto has many built-in features to 
 
 To get started with Alto, create a CloudCannon account and check out the [Getting Started documentation](/docs/).
 
-{{< tweet user="Example tweet" id="463440424141459456" >}}
+{{< tweet user="Interior" id="463440424141459456" >}}
 
 <!--more-->
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -24,8 +24,6 @@ Designed initially for open-source software, Alto has many built-in features to 
 
 To get started with Alto, create a CloudCannon account and check out the [Getting Started documentation](/docs/).
 
-{{< tweet user="Interior" id="463440424141459456" >}}
-
 <!--more-->
 
 ## Showcase

--- a/content/_index.md
+++ b/content/_index.md
@@ -12,7 +12,7 @@ Alto is a minimal and modern Hugo theme for static documentation sites, created 
 
 {{< figure src="/uploads/alto.png" >}}
 
-{{< ref path="_index.md" >}}
+{{< ref path="docs" >}}
 
 {{< relref path="_index.md" >}}
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -10,7 +10,7 @@ draft: false
 ---
 Alto is a minimal and modern Hugo theme for static documentation sites, created by and optimized for <a target="_blank" rel="noopener" href="https://cloudcannon.com">CloudCannon</a>.
 
-{{< ref path="docs/_index" >}}
+{{< ref path="docs/_index.md" >}}
 
 {{< relref path="docs/_index.md" >}}
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -10,7 +10,7 @@ draft: false
 ---
 Alto is a minimal and modern Hugo theme for static documentation sites, created by and optimized for <a target="_blank" rel="noopener" href="https://cloudcannon.com">CloudCannon</a>.
 
-{{< ref path="docs/_index.md" >}}
+{{< ref path="https://google.com" >}}
 
 {{< relref path="docs/_index.md" >}}
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -24,6 +24,8 @@ Designed initially for open-source software, Alto has many built-in features to 
 
 To get started with Alto, create a CloudCannon account and check out the [Getting Started documentation](/docs/).
 
+{{< tweet user="Example tweet" id="463440424141459456" >}}
+
 <!--more-->
 
 ## Showcase

--- a/content/_index.md
+++ b/content/_index.md
@@ -8,7 +8,7 @@ SEO_options:
   description:
 draft: false
 ---
-Alto is a minimal and modern Hugo theme for static documentation sites, created by and optimized for <a target="_blank" rel="noopener" href="https://cloudcannon.com">CloudCannon</a>.{{< ref path="home" lang="html" outputFormat="html" >}}
+Alto is a minimal and modern Hugo theme for static documentation sites, created by and optimized for <a target="_blank" rel="noopener" href="https://cloudcannon.com">CloudCannon</a>.{{< ref path="google.com" lang="html" outputFormat="html" >}}
 
 Designed initially for open-source software, Alto has many built-in features to aid both site users and documentation writers:
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -12,9 +12,9 @@ Alto is a minimal and modern Hugo theme for static documentation sites, created 
 
 {{< figure src="/uploads/alto.png" >}}
 
-{{< ref path="/uploads/alto.png" >}}
 
-{{< relref path="docs/_index.md" >}}
+
+
 
 Designed initially for open-source software, Alto has many built-in features to aid both site users and documentation writers:
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -8,7 +8,7 @@ SEO_options:
   description:
 draft: false
 ---
-Alto is a minimal and modern Hugo theme for static documentation sites, created by and optimized for <a target="_blank" rel="noopener" href="https://cloudcannon.com">CloudCannon</a>.{{< ref path="/pages/index.md" lang="md" outputFormat="html" >}}
+Alto is a minimal and modern Hugo theme for static documentation sites, created by and optimized for <a target="_blank" rel="noopener" href="https://cloudcannon.com">CloudCannon</a>.{{< ref path="docs/_index.md" lang="md" outputFormat="html" >}}
 
 Designed initially for open-source software, Alto has many built-in features to aid both site users and documentation writers:
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -12,7 +12,7 @@ Alto is a minimal and modern Hugo theme for static documentation sites, created 
 
 {{< ref path="docs/_index.md" >}}
 
-{{< relref path="docs/index.md" >}}
+{{< relref path="docs/_index.md" >}}
 
 Designed initially for open-source software, Alto has many built-in features to aid both site users and documentation writers:
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -8,7 +8,7 @@ SEO_options:
   description:
 draft: false
 ---
-Alto is a minimal and modern Hugo theme for static documentation sites, created by and optimized for <a target="_blank" rel="noopener" href="https://cloudcannon.com">CloudCannon</a>.{{< ref path="docs/_index.md" lang="md" outputFormat="html" >}}
+Alto is a minimal and modern Hugo theme for static documentation sites, created by and optimized for <a target="_blank" rel="noopener" href="https://cloudcannon.com">CloudCannon</a>.{{< ref path="docs/_index.md" >}}
 
 Designed initially for open-source software, Alto has many built-in features to aid both site users and documentation writers:
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -24,16 +24,6 @@ Designed initially for open-source software, Alto has many built-in features to 
 
 To get started with Alto, create a CloudCannon account and check out the [Getting Started documentation](/docs/).
 
-{{<tree>}}
-package.json
-_includes/
->> _layouts/
->  >> default.liquid
->  >> page.liquid
->> file.liquid
-_site/
->> index.html
-{{</tree>}}
 
 <!--more-->
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -10,7 +10,9 @@ draft: false
 ---
 Alto is a minimal and modern Hugo theme for static documentation sites, created by and optimized for <a target="_blank" rel="noopener" href="https://cloudcannon.com">CloudCannon</a>.
 
-{{< ref path="docs/_index.md" >}}
+{{< figure src="/uploads/alto.png" >}}
+
+{{< ref path="/uploads/alto.png" >}}
 
 {{< relref path="docs/_index.md" >}}
 

--- a/content/docs/configuring-navigation-footer.md
+++ b/content/docs/configuring-navigation-footer.md
@@ -10,8 +10,6 @@ You can easily configure Alto's Navigation and Footer items within CloudCannon, 
 
 {{< ref path="index.md" >}}
 
-{{< relref path="index.md" >}}
-
 ## Configuring the navigation
 
 You can edit the navigation title, add links, and a site logo.

--- a/content/docs/configuring-navigation-footer.md
+++ b/content/docs/configuring-navigation-footer.md
@@ -8,7 +8,7 @@ draft: false
 ---
 You can easily configure Alto's Navigation and Footer items within CloudCannon, under Alto's **Site Settings**.&nbsp;
 
-{{< ref path="../index.md" >}}
+{{< relref path="../index.md" >}}
 
 Configuring the navigation
 

--- a/content/docs/configuring-navigation-footer.md
+++ b/content/docs/configuring-navigation-footer.md
@@ -8,7 +8,7 @@ draft: false
 ---
 You can easily configure Alto's Navigation and Footer items within CloudCannon, under Alto's **Site Settings**.&nbsp;
 
-{{< relref path="../index.md" >}}
+{{< relref path="index.md" >}}
 
 Configuring the navigation
 

--- a/content/docs/configuring-navigation-footer.md
+++ b/content/docs/configuring-navigation-footer.md
@@ -10,6 +10,8 @@ You can easily configure Alto's Navigation and Footer items within CloudCannon, 
 
 {{< ref path="_index.md" >}}
 
+{{< relref path="_index.md" >}}
+
 ## Configuring the navigation
 
 You can edit the navigation title, add links, and a site logo.

--- a/content/docs/configuring-navigation-footer.md
+++ b/content/docs/configuring-navigation-footer.md
@@ -8,9 +8,9 @@ draft: false
 ---
 You can easily configure Alto's Navigation and Footer items within CloudCannon, under Alto's **Site Settings**.&nbsp;
 
-{{< ref path="configuring-navigation-footer.md" >}}
+{{< ref path="configuring-theme-colors.md" >}}
 
-{{< relref path="configuring-navigation-footer.md" >}}
+{{< relref path="configuring-theme-colors.md" >}}
 
 ## Configuring the navigation
 

--- a/content/docs/configuring-navigation-footer.md
+++ b/content/docs/configuring-navigation-footer.md
@@ -8,7 +8,7 @@ draft: false
 ---
 You can easily configure Alto's Navigation and Footer items within CloudCannon, under Alto's **Site Settings**.&nbsp;
 
-{{< relref path="content/index.md" >}}
+{{< relref path="/_index.md" >}}
 
 Configuring the navigation
 

--- a/content/docs/configuring-navigation-footer.md
+++ b/content/docs/configuring-navigation-footer.md
@@ -8,7 +8,7 @@ draft: false
 ---
 You can easily configure Alto's Navigation and Footer items within CloudCannon, under Alto's **Site Settings**.&nbsp;
 
-{{< ref path="page/index.md" >}}
+{{< ref path="pages/index.md" >}}
 
 Configuring the navigation
 

--- a/content/docs/configuring-navigation-footer.md
+++ b/content/docs/configuring-navigation-footer.md
@@ -8,7 +8,7 @@ draft: false
 ---
 You can easily configure Alto's Navigation and Footer items within CloudCannon, under Alto's **Site Settings**.&nbsp;
 
-{{< ref path="pages/index.md" >}}
+{{< ref path="../index.md" >}}
 
 Configuring the navigation
 

--- a/content/docs/configuring-navigation-footer.md
+++ b/content/docs/configuring-navigation-footer.md
@@ -8,9 +8,9 @@ draft: false
 ---
 You can easily configure Alto's Navigation and Footer items within CloudCannon, under Alto's **Site Settings**.&nbsp;
 
-{{< ref path="docs/customizing_alto/configuring-navigation-footer.md" >}}
+{{< ref path="docs/configuring-navigation-footer.md" >}}
 
-{{< relref path="docs/customizing_alto/configuring-navigation-footer.md" >}}
+{{< relref path="docs/configuring-navigation-footer.md" >}}
 
 ## Configuring the navigation
 

--- a/content/docs/configuring-navigation-footer.md
+++ b/content/docs/configuring-navigation-footer.md
@@ -8,7 +8,7 @@ draft: false
 ---
 You can easily configure Alto's Navigation and Footer items within CloudCannon, under Alto's **Site Settings**.&nbsp;
 
-{{< ref path="index.md" >}}
+{{< ref path="_index.md" >}}
 
 ## Configuring the navigation
 

--- a/content/docs/configuring-navigation-footer.md
+++ b/content/docs/configuring-navigation-footer.md
@@ -8,9 +8,9 @@ draft: false
 ---
 You can easily configure Alto's Navigation and Footer items within CloudCannon, under Alto's **Site Settings**.&nbsp;
 
-{{< ref path="docs/configuring-navigation-footer.md" >}}
+{{< ref path="configuring-navigation-footer.md" >}}
 
-{{< relref path="docs/configuring-navigation-footer.md" >}}
+{{< relref path="configuring-navigation-footer.md" >}}
 
 ## Configuring the navigation
 

--- a/content/docs/configuring-navigation-footer.md
+++ b/content/docs/configuring-navigation-footer.md
@@ -8,6 +8,10 @@ draft: false
 ---
 You can easily configure Alto's Navigation and Footer items within CloudCannon, under Alto's **Site Settings**.&nbsp;
 
+{{< ref path="docs/_index.md" >}}
+
+{{< relref path="docs/_index.md" >}}
+
 ## Configuring the navigation
 
 You can edit the navigation title, add links, and a site logo.

--- a/content/docs/configuring-navigation-footer.md
+++ b/content/docs/configuring-navigation-footer.md
@@ -10,6 +10,8 @@ You can easily configure Alto's Navigation and Footer items within CloudCannon, 
 
 {{< relref path="/_index.md" >}}
 
+{{< ref path="/_index.md" >}}
+
 Configuring the navigation
 
 You can edit the navigation title, add links, and a site logo.

--- a/content/docs/configuring-navigation-footer.md
+++ b/content/docs/configuring-navigation-footer.md
@@ -8,11 +8,9 @@ draft: false
 ---
 You can easily configure Alto's Navigation and Footer items within CloudCannon, under Alto's **Site Settings**.&nbsp;
 
-{{< ref path="_index.md" >}}
+{{< ref path="page/index.md" >}}
 
-{{< relref path="page/index.md" >}}
-
-## Configuring the navigation
+Configuring the navigation
 
 You can edit the navigation title, add links, and a site logo.
 

--- a/content/docs/configuring-navigation-footer.md
+++ b/content/docs/configuring-navigation-footer.md
@@ -8,9 +8,9 @@ draft: false
 ---
 You can easily configure Alto's Navigation and Footer items within CloudCannon, under Alto's **Site Settings**.&nbsp;
 
-{{< ref path="configuring-theme-colors.md" >}}
+{{< ref path="index.md" >}}
 
-{{< relref path="configuring-theme-colors.md" >}}
+{{< relref path="index.md" >}}
 
 ## Configuring the navigation
 

--- a/content/docs/configuring-navigation-footer.md
+++ b/content/docs/configuring-navigation-footer.md
@@ -8,7 +8,7 @@ draft: false
 ---
 You can easily configure Alto's Navigation and Footer items within CloudCannon, under Alto's **Site Settings**.&nbsp;
 
-{{< relref path="_index.md" >}}
+{{< relref path="content/index.md" >}}
 
 Configuring the navigation
 

--- a/content/docs/configuring-navigation-footer.md
+++ b/content/docs/configuring-navigation-footer.md
@@ -8,9 +8,9 @@ draft: false
 ---
 You can easily configure Alto's Navigation and Footer items within CloudCannon, under Alto's **Site Settings**.&nbsp;
 
-{{< relref path="/_index.md" >}}
+{{< relref path="_index.md" >}}
 
-{{< ref path="/_index.md" >}}
+{{< ref path="_index.md" >}}
 
 Configuring the navigation
 

--- a/content/docs/configuring-navigation-footer.md
+++ b/content/docs/configuring-navigation-footer.md
@@ -8,9 +8,9 @@ draft: false
 ---
 You can easily configure Alto's Navigation and Footer items within CloudCannon, under Alto's **Site Settings**.&nbsp;
 
-{{< ref path="docs/_index.md" >}}
+{{< ref path="docs/customizing_alto/configuring-navigation-footer.md" >}}
 
-{{< relref path="docs/_index.md" >}}
+{{< relref path="docs/customizing_alto/configuring-navigation-footer.md" >}}
 
 ## Configuring the navigation
 

--- a/content/docs/configuring-navigation-footer.md
+++ b/content/docs/configuring-navigation-footer.md
@@ -10,7 +10,7 @@ You can easily configure Alto's Navigation and Footer items within CloudCannon, 
 
 {{< ref path="_index.md" >}}
 
-{{< relref path="_index.md" >}}
+{{< relref path="page/index.md" >}}
 
 ## Configuring the navigation
 

--- a/content/docs/configuring-navigation-footer.md
+++ b/content/docs/configuring-navigation-footer.md
@@ -8,7 +8,7 @@ draft: false
 ---
 You can easily configure Alto's Navigation and Footer items within CloudCannon, under Alto's **Site Settings**.&nbsp;
 
-{{< relref path="index.md" >}}
+{{< relref path="_index.md" >}}
 
 Configuring the navigation
 

--- a/data/banner.yml
+++ b/data/banner.yml
@@ -2,3 +2,19 @@ enable_banner: true
 html: <p>This banner is completely optional, and can be shown until a set date!</p>
 id: alto-banner
 show_until: 2023-07-20T07:28:00Z
+_inputs:
+  enable_banner:
+    type: switch
+  html:
+    type: html
+    label: Banner Content
+    hidden: '!enable_banner'
+  id:
+    type: text
+    label: Unique ID
+    hidden: '!enable_banner'
+    comment: Prevents repeated display for users who close the banner, changing ID resets for all.
+  show_until:
+    type: date
+    comment: Date to stop showing the banner
+    hidden: '!enable_banner'


### PR DESCRIPTION
# Context

Missing ID in Tweet shortcode
![Screenshot 2023-11-14 at 8 44 37 AM](https://github.com/CloudCannon/alto-hugo-template/assets/147457997/faa5373e-32f1-46fe-8734-5b9752d01c9c)

# Additional information

- Caused by banner 'id' field being set in global cloudcannon.config.yml
- Removed banner config options from cloudcannon.config.yml to data/banner.yml

# Testing (tester)

The reviewer should check on this branch:

- The code
- The site [Link here](https://aware-daffodil.cloudvent.net/)

# Before merge (PR owner)

- [ ] Delete the test site in CloudCannon
- [ ] Remove example tweet from index page
