### PR TITLE
Feat: December update

### DIFF
--- a/assets/css/code.scss
+++ b/assets/css/code.scss
@@ -83,3 +83,92 @@
 /* GenericTraceback */ .chroma .gt { color: #aa0000 }
 /* GenericUnderline */ .chroma .gl { text-decoration: underline }
 /* TextWhitespace */ .chroma .w { color: #bbbbbb }
+
+body.dark {
+    /* Background */ .bg { color: #c9d1d9; background-color: #0d1117; }
+    /* PreWrapper */ .chroma { color: #c9d1d9; background-color: #0d1117; }
+    /* Other */ .chroma .x {  }
+    /* Error */ .chroma .err { color: #f85149 }
+    /* CodeLine */ .chroma .cl {  }
+    /* LineLink */ .chroma .lnlinks { outline: none; text-decoration: none; color: inherit }
+    /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
+    /* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; }
+    /* LineHighlight */ .chroma .hl { background-color: #ffffcc }
+    /* LineNumbersTable */ .chroma .lnt { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #64686c }
+    /* LineNumbers */ .chroma .ln { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #6e7681 }
+    /* Line */ .chroma .line { display: flex; }
+    /* Keyword */ .chroma .k { color: #ff7b72 }
+    /* KeywordConstant */ .chroma .kc { color: #79c0ff }
+    /* KeywordDeclaration */ .chroma .kd { color: #ff7b72 }
+    /* KeywordNamespace */ .chroma .kn { color: #ff7b72 }
+    /* KeywordPseudo */ .chroma .kp { color: #79c0ff }
+    /* KeywordReserved */ .chroma .kr { color: #ff7b72 }
+    /* KeywordType */ .chroma .kt { color: #ff7b72 }
+    /* Name */ .chroma .n {  }
+    /* NameAttribute */ .chroma .na { color: #79c0ff }
+    /* NameBuiltin */ .chroma .nb {  }
+    /* NameBuiltinPseudo */ .chroma .bp {  }
+    /* NameClass */ .chroma .nc { color: #f0883e; font-weight: bold }
+    /* NameConstant */ .chroma .no { color: #79c0ff; font-weight: bold }
+    /* NameDecorator */ .chroma .nd { color: #d2a8ff; font-weight: bold }
+    /* NameEntity */ .chroma .ni { color: #ffa657 }
+    /* NameException */ .chroma .ne { color: #f0883e; font-weight: bold }
+    /* NameFunction */ .chroma .nf { color: #d2a8ff; font-weight: bold }
+    /* NameFunctionMagic */ .chroma .fm {  }
+    /* NameLabel */ .chroma .nl { color: #79c0ff; font-weight: bold }
+    /* NameNamespace */ .chroma .nn { color: #ff7b72 }
+    /* NameOther */ .chroma .nx {  }
+    /* NameProperty */ .chroma .py { color: #79c0ff }
+    /* NameTag */ .chroma .nt { color: #7ee787 }
+    /* NameVariable */ .chroma .nv { color: #79c0ff }
+    /* NameVariableClass */ .chroma .vc {  }
+    /* NameVariableGlobal */ .chroma .vg {  }
+    /* NameVariableInstance */ .chroma .vi {  }
+    /* NameVariableMagic */ .chroma .vm {  }
+    /* Literal */ .chroma .l { color: #a5d6ff }
+    /* LiteralDate */ .chroma .ld { color: #79c0ff }
+    /* LiteralString */ .chroma .s { color: #a5d6ff }
+    /* LiteralStringAffix */ .chroma .sa { color: #79c0ff }
+    /* LiteralStringBacktick */ .chroma .sb { color: #a5d6ff }
+    /* LiteralStringChar */ .chroma .sc { color: #a5d6ff }
+    /* LiteralStringDelimiter */ .chroma .dl { color: #79c0ff }
+    /* LiteralStringDoc */ .chroma .sd { color: #a5d6ff }
+    /* LiteralStringDouble */ .chroma .s2 { color: #a5d6ff }
+    /* LiteralStringEscape */ .chroma .se { color: #79c0ff }
+    /* LiteralStringHeredoc */ .chroma .sh { color: #79c0ff }
+    /* LiteralStringInterpol */ .chroma .si { color: #a5d6ff }
+    /* LiteralStringOther */ .chroma .sx { color: #a5d6ff }
+    /* LiteralStringRegex */ .chroma .sr { color: #79c0ff }
+    /* LiteralStringSingle */ .chroma .s1 { color: #a5d6ff }
+    /* LiteralStringSymbol */ .chroma .ss { color: #a5d6ff }
+    /* LiteralNumber */ .chroma .m { color: #a5d6ff }
+    /* LiteralNumberBin */ .chroma .mb { color: #a5d6ff }
+    /* LiteralNumberFloat */ .chroma .mf { color: #a5d6ff }
+    /* LiteralNumberHex */ .chroma .mh { color: #a5d6ff }
+    /* LiteralNumberInteger */ .chroma .mi { color: #a5d6ff }
+    /* LiteralNumberIntegerLong */ .chroma .il { color: #a5d6ff }
+    /* LiteralNumberOct */ .chroma .mo { color: #a5d6ff }
+    /* Operator */ .chroma .o { color: #ff7b72; font-weight: bold }
+    /* OperatorWord */ .chroma .ow { color: #ff7b72; font-weight: bold }
+    /* Punctuation */ .chroma .p {  }
+    /* Comment */ .chroma .c { color: #8b949e; font-style: italic }
+    /* CommentHashbang */ .chroma .ch { color: #8b949e; font-style: italic }
+    /* CommentMultiline */ .chroma .cm { color: #8b949e; font-style: italic }
+    /* CommentSingle */ .chroma .c1 { color: #8b949e; font-style: italic }
+    /* CommentSpecial */ .chroma .cs { color: #8b949e; font-weight: bold; font-style: italic }
+    /* CommentPreproc */ .chroma .cp { color: #8b949e; font-weight: bold; font-style: italic }
+    /* CommentPreprocFile */ .chroma .cpf { color: #8b949e; font-weight: bold; font-style: italic }
+    /* Generic */ .chroma .g {  }
+    /* GenericDeleted */ .chroma .gd { color: #ffa198; background-color: #490202 }
+    /* GenericEmph */ .chroma .ge { font-style: italic }
+    /* GenericError */ .chroma .gr { color: #ffa198 }
+    /* GenericHeading */ .chroma .gh { color: #79c0ff; font-weight: bold }
+    /* GenericInserted */ .chroma .gi { color: #56d364; background-color: #0f5323 }
+    /* GenericOutput */ .chroma .go { color: #8b949e }
+    /* GenericPrompt */ .chroma .gp { color: #8b949e }
+    /* GenericStrong */ .chroma .gs { font-weight: bold }
+    /* GenericSubheading */ .chroma .gu { color: #79c0ff }
+    /* GenericTraceback */ .chroma .gt { color: #ff7b72 }
+    /* GenericUnderline */ .chroma .gl { text-decoration: underline }
+    /* TextWhitespace */ .chroma .w { color: #6e7681 }
+  }

--- a/assets/css/dark-styles.scss
+++ b/assets/css/dark-styles.scss
@@ -20,49 +20,6 @@ body{
             }
         }
 
-        .chroma {
-            background-color: var(--background-body);
-
-            .o {
-                color: var(--text);
-            }
-
-            .nt {
-                color: var(--code-element);
-            }
-
-            .na {
-                color: var(--code-attribute);
-            }
-
-            .s {
-                color: var(--code-params);
-            }
-
-            .kc {
-                color: var(--code-bool);
-            }
-
-            .s2 {
-                color: var(--code-values);
-            }
-
-            .mi {
-                color: var(--highlight);
-            }
-
-           
-        }
-
-
-        [data-add]>span {
-            background-color: var(--diffcode-added);
-        }
-
-        [data-remove]>span {
-            background-color: var(--diffcode-removed);
-        }
-
         .header>.row .logo-dark {
             display: block;
         }

--- a/assets/css/elements.scss
+++ b/assets/css/elements.scss
@@ -49,21 +49,46 @@ pre>code {
 }
 
 // Styles for our diffcode shortcode
-[data-add] {
+[data-add], [data-remove] {
     position: relative;
 
     &::before {
-        content: "+";
         position: absolute;
         right: calc(100% + 3px);
-        color: #6ac86aa6;
         font-weight: bold;
         pointer-events: none;
         user-select: none;
+        filter: brightness(0.7) saturate(2);
+
+        body.dark & {
+            filter: brightness(2) saturate(2);
+        }
+    }
+}
+
+[data-add] {
+    &::before {
+        content: "+";
+        color: var(--diffcode-added);
     }
 
     &>span {
-        background-color: #ddffddcf;
+        background-color: var(--diffcode-added);
+    }
+}
+[data-remove] {
+    &::before {
+        content: "-";
+        color: var(--diffcode-removed);
+    }
+
+    &>span {
+        background-color: var(--diffcode-removed);
+    }
+}
+[data-highlight] {
+    &>span {
+        background-color: var(--diffcode-highlighted);
     }
 }
 

--- a/cloudcannon.config.yml
+++ b/cloudcannon.config.yml
@@ -390,6 +390,12 @@ _inputs:
       format: hex
       alpha: true
     comment: Background color for removed lines in diffcode shortcode.
+  diffcode-highlighted: 
+    type: color
+    options:
+      format: hex
+      alpha: true
+    comment: Background color for highlighted lines in diffcode shortcode.
   pagefind-ui-primary:
     type: color
     comment: Primary color for pagefind ui. 

--- a/data/theme.yml
+++ b/data/theme.yml
@@ -35,8 +35,9 @@ colors:
     focus_colors:
       focus: '#0096bfab'
     shortcode_colors:
-      diffcode-added: '#003506'
-      diffcode-removed: '#350000'
+      diffcode-added: '#ddffddcf'
+      diffcode-removed: '#ffc8c8'
+      diffcode-highlighted: '#fffece'
     pagefind_colors:
       pagefind-ui-primary: '#000000'
       pagefind-ui-secondary: '#000000'
@@ -45,12 +46,12 @@ colors:
       pagefind-ui-tag: '#efefef'
   dark:
     typography:
-      text: '#dbdbdb'
-      flip-text: '#dbdbdb'
-      text-main: '#dbdbdb'
+      text: '#e6edf3'
+      flip-text: '#e6edf3'
+      text-main: '#e6edf3'
       text-bright: '#ffffff'
       text-muted: '#c8c8c8'
-      links: '#de935f'
+      links: '#58a4e0'
       highlight: '#de935f'
       selection: '#616161'
       form-placeholder: '#e0e0e0'
@@ -76,10 +77,11 @@ colors:
     border_colors:
       border: '#dbdbdb'
     focus_colors:
-      focus: '#ff4d4d'
+      focus: '#0096bfab'
     shortcode_colors:
       diffcode-added: '#003506'
       diffcode-removed: '#350000'
+      diffcode-highlighted: '#ffd7002e'
     pagefind_colors:
       pagefind-ui-primary: '#D8D8D8'
       pagefind-ui-secondary: '#D8D8D8'

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
+module github.com/CloudCannon/alto-hugo-template
+
 go 1.18

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -31,6 +31,8 @@
     {{ $style := resources.Get "css/site.scss" | toCSS | minify | fingerprint }}
     <link rel="stylesheet" href="{{ $style.Permalink }}">
 
+    {{ partial "extra_head.html" . }}
+
     <title>{{.Params.title}} | {{ site.Data.meta.project_name }}</title>
 
     <style>
@@ -70,7 +72,7 @@
 
     <script>
         window.addEventListener('DOMContentLoaded', (event) => {
-            new PagefindUI({ element: "#search" });
+            new PagefindUI({ element: "#search", showSubResults: true, showImages: false });
         });
     </script>
 

--- a/layouts/partials/diffcode.html
+++ b/layouts/partials/diffcode.html
@@ -1,18 +1,24 @@
 
 {{ $diffBlock := (. | replaceRE "(?m:^```\\w+)" "```diff") }}
 {{ $diffBlock := (index (split $diffBlock "```") 1) }}
-{{ $diffBlock =  ($diffBlock | replaceRE "(?m:^([+-])?.*$)" "$1") }}
+{{ $diffBlock =  ($diffBlock | replaceRE "(?m:^([+\\-~])?.*$)" "$1") }}
 {{ $diffBlock =  ($diffBlock | replaceRE "(?m:^$)" "." | replaceRE "\n" "") }}
 
 {{ $lines := split $diffBlock "" }}
 
-{{ $mainBlock :=  (. | replaceRE "(?m:^[+-])" "") | markdownify }}
+{{ $mainBlock :=  (. | replaceRE "(?m:^[+\\-~])" "") | markdownify }}
 
 {{ range $i, $l := (split $mainBlock `class="line"`)}}
     {{ if gt $i 0}}
         class="line"
         {{ if eq (index $lines $i) "+" }}
         data-add="true"
+        {{ end }}
+        {{ if eq (index $lines $i) "-" }}
+        data-remove="true"
+        {{ end }}
+        {{ if eq (index $lines $i) "~" }}
+        data-highlight="true"
         {{ end }}
     {{ end }}
     {{$l | safeHTML}}

--- a/layouts/partials/extra_head.html
+++ b/layouts/partials/extra_head.html
@@ -1,0 +1,1 @@
+{{/* Extra <head> content may be inserted here */}}


### PR DESCRIPTION
- enables site to be used as Hugo Module
- Adds `showSubResults: true` to the Pagefind init
- Adds `extra_head.html` which allows the site to be used as a theme without overriding the full baseof
- Added `~` as a character to diffcode, which highlights lines.
- Various style changes.