### PR TITLE
Fix: removed stray closing button tag from docnav partial

### DIFF
--- a/layouts/partials/docnav.html
+++ b/layouts/partials/docnav.html
@@ -2,7 +2,6 @@
 
 <nav class="docnav" aria-label="{{ site.Data.nav.side_nav_title }}">
     <span class="docnav-title">{{ site.Data.nav.side_nav_title }}</span>
-   </button>
     <div id="docnav-inner" class="docnav-inner">
         {{ partial "docnav-list.html" . }}
     </div>


### PR DESCRIPTION
- Small PR to remove an unnecessary stray closing button tag in docnav.html